### PR TITLE
[FIX] No subject_signature_number

### DIFF
--- a/models/company_signature_key.py
+++ b/models/company_signature_key.py
@@ -191,7 +191,7 @@ class userSignature(models.Model):
     subject_title = fields.Char('Subject Title', readonly=True)
     subject_c = fields.Char('Subject Country', readonly=True)
     subject_serial_number = fields.Char(
-        'Subject Serial Number', readonly=True)
+        'Subject Serial Number')
     subject_common_name = fields.Char(
         'Subject Common Name', readonly=True)
     subject_email_address = fields.Char(

--- a/models/user_signature_key.py
+++ b/models/user_signature_key.py
@@ -191,7 +191,7 @@ class userSignature(models.Model):
     subject_title = fields.Char('Subject Title', readonly=True)
     subject_c = fields.Char('Subject Country', readonly=True)
     subject_serial_number = fields.Char(
-        'Subject Serial Number', readonly=True)
+        'Subject Serial Number')
     subject_common_name = fields.Char(
         'Subject Common Name', readonly=True)
     subject_email_address = fields.Char(

--- a/views/company_signature_tab.xml
+++ b/views/company_signature_tab.xml
@@ -36,7 +36,7 @@
                                 <field name="final_date"/>
                                 <field name="subject_title"/>
                                 <field name="subject_c"/>
-                                <field name="subject_serial_number"/>
+                                <field name="subject_serial_number" attrs="{'readonly':[('subject_serial_number','=',True)]}"/>
                                 <field name="subject_common_name"/>
                                 <field name="subject_email_address"/>
                                 <field name="issuer_country"/>

--- a/views/user_signature_tab.xml
+++ b/views/user_signature_tab.xml
@@ -36,7 +36,7 @@
                                 <field name="final_date"/>
                                 <field name="subject_title"/>
                                 <field name="subject_c"/>
-                                <field name="subject_serial_number"/>
+                                <field name="subject_serial_number" attrs="{'readonly':[('subject_serial_number','=',True)]}"/>
                                 <field name="subject_common_name"/>
                                 <field name="subject_email_address"/>
                                 <field name="issuer_country"/>
@@ -110,6 +110,3 @@
 
     </data>
 </openerp>
-
-
-


### PR DESCRIPTION
En algunos casos, cuando la firma no ha sido bien configurada, viene
sin el rut  o el código no lo detecta,
le damos la posilbilidad de agregarlo a "mano"
